### PR TITLE
Address minor mistakes in my initial documentation

### DIFF
--- a/source/installation/installing-qucs-s.md
+++ b/source/installation/installing-qucs-s.md
@@ -31,6 +31,10 @@ QUCS-S can be installed on FreeBSD using either ports or a binary package.
 * To install ports: ``cd /usr/ports/cad/qucs-s/ && make install clean``
 * To install binary package: ``pkg install qucs-s``
 
+## Compiling from Source
+
+Of course, Qucs-S can be compiled from source if desired. See the main [Qucs-S GitHub repository's README](https://github.com/ra3xdh/qucs_s/blob/current/README.md) for the latest information on how to compile from source.
+
 ---
 
 Once you have installed QUCS-S, you will likely need to install simulation backends separately. This is covered in the next chapter.

--- a/source/installation/installing-qucs-s.md
+++ b/source/installation/installing-qucs-s.md
@@ -12,6 +12,8 @@ OSX installation ``.dmg``'s are available [with each Release on GitHub.](https:/
 
 There are also homebrew packages available [in a separate GitHub repository.](https://github.com/ra3xdh/homebrew-qucs-s)
 
+Only the QucsatorRF simulation backend is included with these binaries. Other simulation backends will need to be installed separately.
+
 ## Linux
 
 For Debian, Ubuntu, Fedora, and OpenSUSE, [``.deb`` and ``.rpm`` packages are available on the OpenSUSE Build Service.](https://software.opensuse.org/download.html?project=home%3Ara3xdh&package=qucs-s) Simply follow the installation instructions on the build service page.
@@ -20,7 +22,7 @@ Arch and Manjaro users may install QUCS-S from [AUR](https://aur.archlinux.org/p
 
 AltLinux packages are available from Sysyphus repo, [here.](https://packages.altlinux.org/ru/sisyphus/srpms/qucs-s/)
 
-> **Note: If you install on Ubuntu or Debian using the packages above, the ``ngspice`` simulator is installed automatically.** If you wish to use any of the other supported simulation backends, you will need to install them separately._
+> **Note: If you install on Ubuntu or Debian using the packages above, the ``ngspice`` simulator and the QucsatorRF simulator are both installed automatically.** Other platforms only come with QucsatorRF installed. If you wish to use any of the other supported simulation backends, you will need to install them separately._
 
 For all other distributions, an AppImage file is available. [Get the latest release from GitHub.](https://github.com/ra3xdh/qucs_s/releases)
 
@@ -31,10 +33,12 @@ QUCS-S can be installed on FreeBSD using either ports or a binary package.
 * To install ports: ``cd /usr/ports/cad/qucs-s/ && make install clean``
 * To install binary package: ``pkg install qucs-s``
 
+Only the QucsatorRF simulation backend is included with this install method. Other simulation backends will need to be installed separately.
+
 ## Compiling from Source
 
 Of course, Qucs-S can be compiled from source if desired. See the main [Qucs-S GitHub repository's README](https://github.com/ra3xdh/qucs_s/blob/current/README.md) for the latest information on how to compile from source.
 
 ---
 
-Once you have installed QUCS-S, you will likely need to install simulation backends separately. This is covered in the next chapter.
+Once you have installed QUCS-S, you may need to install simulation backends separately. This is covered in the next chapter.

--- a/source/introduction/what-is-qucs-s.md
+++ b/source/introduction/what-is-qucs-s.md
@@ -16,10 +16,15 @@ The original Qucs project uses its own SPICE-incompatible simulator, called Qucs
 
 In contrast to Qucs and QucsStudio, QUCS-S does not include its own simulation backend at all. Rather, it serves as a frontend for several different simulation backends:
 
+### Analog/Digital/RF Simulators
 * **[ngspice (recommended)](https://ngspice.sourceforge.io/)**: A powerful mixed-level/mixed-signal circuit simulator. Most SPICE models distributed across industry are compatible with it. It has excellent performance for time-domain simulation of switching circuits, and a powerful postprocessor. If you are unsure which simulation backend to use with QUCS-S, ngspice is recommended.
 * **[Xyce](https://xyce.sandia.gov/)**: A new SPICE-compatible circuit simulator, written from scratch by Sandia National Laboratory. Xyce has the notable advantage of supporting large-scale parallel computing platforms, making it a good fit for solving very large circuits (although it can run on an ordinary desktop platform as well).
 * **[SpiceOpus](https://www.spiceopus.si/)**: A free general purpose circuit simulator, based on the Berkeley SPICE-3f5 codebas, specially suited for optimization loops.
 * **[QucsatorRF](https://github.com/ra3xdh/qucsator_rf)**: A fork of Qucsator, the built-in simulation engine from the original [Qucs](https://qucs.sourceforge.net) project. QucsatorRF shares the original Qucsator netlist syntax, and all RF features. It's primarily intended for RF simulation with microwave devices and microstrip lines. It is not generally recommended for general-purpose circuit simulation, since ngspice typically has better performance.
+
+### Digital-Only Simulators
+* **[Icarus Verilog](https://steveicarus.github.io/iverilog/)**: A digital-only simulation backend for simulating Verilog devices.
+* **[FreeHDL](http://freehdl.seul.org/)**: A digital-only simulation backend for simulating VHDL devices.
 
 ## Notable Features
 

--- a/source/introduction/what-is-qucs-s.md
+++ b/source/introduction/what-is-qucs-s.md
@@ -19,7 +19,7 @@ In contrast to Qucs and QucsStudio, QUCS-S does not include its own simulation b
 * **[ngspice (recommended)](https://ngspice.sourceforge.io/)**: A powerful mixed-level/mixed-signal circuit simulator. Most SPICE models distributed across industry are compatible with it. It has excellent performance for time-domain simulation of switching circuits, and a powerful postprocessor. If you are unsure which simulation backend to use with QUCS-S, ngspice is recommended.
 * **[Xyce](https://xyce.sandia.gov/)**: A new SPICE-compatible circuit simulator, written from scratch by Sandia National Laboratory. Xyce has the notable advantage of supporting large-scale parallel computing platforms, making it a good fit for solving very large circuits (although it can run on an ordinary desktop platform as well).
 * **[SpiceOpus](https://www.spiceopus.si/)**: A free general purpose circuit simulator, based on the Berkeley SPICE-3f5 codebas, specially suited for optimization loops.
-* **[QucsatorRF](https://github.com/ra3xdh/qucsator_rf)**: A new simulation engine, intended for RF simulation with microwave devices and microstrip lines. It is distinct from the Qucsator simulator used in the original Qucs project. It is not recommended for general-purpose circuit simulation.
+* **[QucsatorRF](https://github.com/ra3xdh/qucsator_rf)**: A fork of Qucsator, the built-in simulation engine from the original [Qucs](https://qucs.sourceforge.net) project. QucsatorRF shares the original Qucsator netlist syntax, and all RF features. It's primarily intended for RF simulation with microwave devices and microstrip lines. It is not generally recommended for general-purpose circuit simulation, since ngspice typically has better performance.
 
 ## Notable Features
 
@@ -45,6 +45,6 @@ A few features of particular note are:
 
 QUCS-S is available for Windows and Mac OSX, as well as numerous Linux distributions.
 
-Keep in mind that simulation backend(s) may need to be installed separately from QUCS-S, depending on your installation platform and method.
+Keep in mind that some simulation backends may need to be installed separately from QUCS-S, depending on your installation platform and method.
 
 See [Installing QUCS-S](/installation/installing-qucs-s) for more information.


### PR DESCRIPTION
This PR should solve the issues described in #19. It does the following:

* Mentions that all builds come with QucsatorRF
* Mentions that QucsatorRF is a fork of original Qucsator, with compatible netlist syntax and all RF devices
* Adds a link to the "Installing Qucs-S" page to the main Git repo, for compiling from source
* Adds reference to the FreeHDL and IVerilog backends to the "What is QUCS-S?" page, where the other simulation backends are mentioned.

Please review documentation preview below for accuracy.

<!-- readthedocs-preview qucs-s-help start -->
----
📚 Documentation preview 📚: https://qucs-s-help--20.org.readthedocs.build/en/20/

<!-- readthedocs-preview qucs-s-help end -->